### PR TITLE
Sets up RuboCop on CI

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,5 @@
+version: "2"
+plugins:
+  rubocop:
+    enabled: true
+    channel: rubocop-0-76

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ spec/dummy/log/test.log
 *.gem
 gemfiles/*.lock
 Gemfile.lock
+.byebug_history
 .ruby-gemset
 .ruby-version
 

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,0 @@
-ruby:
-  enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+AllCops:
+  Exclude:
+    - 'gemfiles/*.gemfile'
+    - 'spec/dummy/db/schema.rb'
+
+Metrics/LineLength:
+  Max: 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ gemfile:
   - gemfiles/rails_6.0.0.gemfile
 
 language: ruby
+bundler_args: --with development
 rvm:
   - 2.2
   - 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,9 @@ gemspec
 
 # To use debugger
 # gem 'debugger'
+
+group :linters do
+  gem "rubocop", "0.76.0"
+  gem "rubocop-rails", "2.4.1"
+  gem "rubocop-rspec", "1.37.1"
+end

--- a/starburst.gemspec
+++ b/starburst.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara", "~> 2.4.1"
   s.add_development_dependency "factory_girl_rails", "~> 4.4.1"
   s.add_development_dependency "appraisal", "1.0.2"
+  s.add_development_dependency "byebug"
 end


### PR DESCRIPTION
- [x] Add RuboCop and its extensions as development dependencies.
- [x] Basic RuboCop settings.
- [x] Remove Hound CI permissions.
- [x] Configure the RuboCop plugin on CodeClimate.