### PR TITLE
Improve test coverage

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+SimpleCov.start :rails do
+  add_filter File.join('lib', 'starburst', 'version.rb')
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 ### 2.0.0 (Unreleased)
 
+#### Breaking changes
 * Drops support for Rails versions 3.0, 3.1, 3.2, 4.0 and 4.1.
+* Raises an error if `Starburst::Announcement.current` is called with a `nil` argument.
+
+#### Improvements
 * Adds support for Rails versions 4.2, 5.0, 5.1, 5.2 and 6.0.
-* Adds support for changing the base controller which `Starburst::AnnouncementsController` inherits from.
 * Removed `Configuration` module.
 * `Starburst.current_user_method` now defaults to a symbol value.
 * `Starburst.user_instance_methods` now defaults to an empty array.
+
+#### New features
+* Adds support for changing the base controller which `Starburst::AnnouncementsController` inherits from.
 * Include private and protected methods when searching for `Starburst.current_user_method`.
 
 ### 1.0.3

--- a/app/models/starburst/announcement.rb
+++ b/app/models/starburst/announcement.rb
@@ -5,10 +5,6 @@ module Starburst
 
 		serialize :limit_to_users
 
-		if Rails::VERSION::MAJOR < 4
-			attr_accessible :title, :body, :start_delivering_at, :stop_delivering_at, :limit_to_users
-		end
-
 		scope :ready_for_delivery, lambda {
 			where("(start_delivering_at < ? OR start_delivering_at IS NULL)
 				AND (stop_delivering_at > ? OR stop_delivering_at IS NULL)", Time.current, Time.current)

--- a/app/models/starburst/announcement.rb
+++ b/app/models/starburst/announcement.rb
@@ -20,7 +20,7 @@ module Starburst
 		scope :in_delivery_order, lambda { order("start_delivering_at ASC")}
 
 		def self.current(current_user)
-			raise ArgumentError, 'User is required to find current Announcement' unless current_user.present?
+			raise ArgumentError, 'User is required to find current announcement' unless current_user.present?
 
 			find_announcement_for_current_user(ready_for_delivery.unread_by(current_user).in_delivery_order, current_user)
 		end

--- a/app/models/starburst/announcement.rb
+++ b/app/models/starburst/announcement.rb
@@ -19,12 +19,10 @@ module Starburst
 
 		scope :in_delivery_order, lambda { order("start_delivering_at ASC")}
 
-		def self.current(current_user = nil)
-			if current_user
-				find_announcement_for_current_user(ready_for_delivery.unread_by(current_user).in_delivery_order, current_user)
-			else
-				ready_for_delivery.in_delivery_order.first
-			end
+		def self.current(current_user)
+			raise ArgumentError, 'User is required to find current Announcement' unless current_user.present?
+
+			find_announcement_for_current_user(ready_for_delivery.unread_by(current_user).in_delivery_order, current_user)
 		end
 
 		def self.find_announcement_for_current_user(announcements, user)

--- a/app/models/starburst/announcement_view.rb
+++ b/app/models/starburst/announcement_view.rb
@@ -1,9 +1,5 @@
 module Starburst
 	class AnnouncementView < ActiveRecord::Base
-		if Rails::VERSION::MAJOR < 4
-			attr_accessible :announcement_id, :user_id
-		end
-		
 		belongs_to :announcement
 		belongs_to :user
 

--- a/spec/controllers/starburst/announcements_controller_spec.rb
+++ b/spec/controllers/starburst/announcements_controller_spec.rb
@@ -17,20 +17,20 @@ RSpec.describe Starburst::AnnouncementsController do
 
     before { allow(controller).to receive(:current_user).and_return(current_user) }
 
-    context 'with a signed in User' do
+    context 'with a signed in user' do
       let(:current_user) { instance_double(User, id: 10) }
 
-      context 'when the User has not marked the Announcement as read yet' do
+      context 'when the user has not marked the announcement as read yet' do
         let(:announcement_view) { an_object_having_attributes(user_id: current_user.id) }
 
         it { expect(mark_as_read).to have_http_status(:ok) }
 
-        it 'marks the Announcement as viewed by the signed in User' do
+        it 'marks the announcement as viewed by the signed in user' do
           expect { mark_as_read }.to change(Starburst::AnnouncementView, :all).to contain_exactly(announcement_view)
         end
       end
 
-      context 'when the User has already marked the Announcement as read' do
+      context 'when the user has already marked the announcement as read' do
         before { create(:announcement_view, user_id: current_user.id, announcement: announcement) }
 
         it { expect(mark_as_read).to have_http_status(:ok) }
@@ -38,7 +38,7 @@ RSpec.describe Starburst::AnnouncementsController do
       end
     end
 
-    context 'without a signed in User' do
+    context 'without a signed in user' do
       let(:current_user) { nil }
 
       it { expect(mark_as_read).to have_http_status(:unprocessable_entity) }

--- a/spec/controllers/starburst/announcements_controller_spec.rb
+++ b/spec/controllers/starburst/announcements_controller_spec.rb
@@ -17,18 +17,28 @@ RSpec.describe Starburst::AnnouncementsController do
 
     before { allow(controller).to receive(:current_user).and_return(current_user) }
 
-    context 'with a signed in user' do
+    context 'with a signed in User' do
       let(:current_user) { instance_double(User, id: 10) }
-      let(:announcement_view) { an_object_having_attributes(user_id: current_user.id) }
 
-      it { expect(mark_as_read).to have_http_status(:ok) }
+      context 'when the User has not marked the Announcement as read yet' do
+        let(:announcement_view) { an_object_having_attributes(user_id: current_user.id) }
 
-      it 'marks the announcement as viewed by the signed in user' do
-        expect { mark_as_read }.to change(Starburst::AnnouncementView, :all).to contain_exactly(announcement_view)
+        it { expect(mark_as_read).to have_http_status(:ok) }
+
+        it 'marks the Announcement as viewed by the signed in User' do
+          expect { mark_as_read }.to change(Starburst::AnnouncementView, :all).to contain_exactly(announcement_view)
+        end
+      end
+
+      context 'when the User has already marked the Announcement as read' do
+        before { create(:announcement_view, user_id: current_user.id, announcement: announcement) }
+
+        it { expect(mark_as_read).to have_http_status(:ok) }
+        it { expect { mark_as_read }.not_to change(Starburst::AnnouncementView, :count) }
       end
     end
 
-    context 'without a signed in user' do
+    context 'without a signed in User' do
       let(:current_user) { nil }
 
       it { expect(mark_as_read).to have_http_status(:unprocessable_entity) }

--- a/spec/features/announcements_spec.rb
+++ b/spec/features/announcements_spec.rb
@@ -3,27 +3,27 @@
 RSpec.describe 'Announcements' do
   let!(:announcement) { create(:announcement) }
 
-  context 'when the User is signed in' do
+  context 'when the user is signed in' do
     let(:current_user) { create(:user) }
 
     before { visit root_path(user_id: current_user.id) }
 
-    it 'displays the current Announcement' do
+    it 'displays the current announcement' do
       expect(page).to have_content('Sample homepage')
       expect(page).to have_content(announcement.body)
     end
 
-    skip 'hides the Announcement if the User closes it', js: true, driver: :selenium_chrome_headless do
+    skip 'hides the announcement if the user closes it', js: true, driver: :selenium_chrome_headless do
       expect(page).to have_content(announcement.body)
       find('#starburst-close').click
       expect(page).not_to have_content(announcement.body)
     end
   end
 
-  context 'when the User is not signed in' do
+  context 'when the user is not signed in' do
     before { visit root_path }
 
-    it 'does not display the current Announcement' do
+    it 'does not display the current announcement' do
       expect(page).to have_content('Sample homepage')
       expect(page).not_to have_content(announcement.body)
     end

--- a/spec/models/starburst/announcement_spec.rb
+++ b/spec/models/starburst/announcement_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Starburst::Announcement do
   end
 
   describe '.current' do
-    subject { described_class.current(user) }
+    subject(:current) { described_class.current(user) }
 
     let(:user) { create(:user) }
 
@@ -18,6 +18,13 @@ RSpec.describe Starburst::Announcement do
 
         it { is_expected.to eq(second_announcement) }
       end
+    end
+
+    context 'when the provided User is nil' do
+      let(:user) { nil }
+      let(:message) { 'User is required to find current Announcement' }
+
+      it { expect { current }.to raise_error(ArgumentError).with_message(message) }
     end
 
     context 'when it is expired' do

--- a/spec/models/starburst/announcement_spec.rb
+++ b/spec/models/starburst/announcement_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe Starburst::Announcement do
       end
     end
 
-    context 'when the provided User is nil' do
+    context 'when the provided user is nil' do
       let(:user) { nil }
-      let(:message) { 'User is required to find current Announcement' }
+      let(:message) { 'User is required to find current announcement' }
 
       it { expect { current }.to raise_error(ArgumentError).with_message(message) }
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,6 @@
 
 # Enabling code coverage reporting
 require 'simplecov'
-SimpleCov.start 'rails'
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ require 'simplecov'
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('dummy/config/environment.rb', __dir__)
+require File.expand_path(File.join(__dir__, 'dummy', 'config', 'environment.rb'))
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -24,7 +24,7 @@ require 'rspec/rails'
 # require only the support files necessary.
 #
 
-Dir[File.join(__dir__, 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[File.join(__dir__, 'support', '**', '*.rb')].sort.each(&method(:require))
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.


### PR DESCRIPTION
- Filters version file from `SimpleCov` reporting.
- Removes conditionals to support Rails versions < 4.0.0.
- Remove code to return current `Announcement` when a `nil` argument is provided and raises an error instead.